### PR TITLE
Restyle login, file editors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ coverage.xml
 
 # Django stuff:
 *.log
+*.log.*
 local_settings.py
 db.sqlite3
 static/*

--- a/data_driven_acquisition/templates/base_uswds.html
+++ b/data_driven_acquisition/templates/base_uswds.html
@@ -28,14 +28,16 @@
                     </div>
                     <button class="usa-menu-btn">Menu</button>
                 </div>
-                <nav aria-label="Primary navigation" class="usa-nav">
-                    <button class="usa-nav__close"><img src="{% static '/img/close.svg' %}" alt="close"></button>
-                    <ul class="usa-nav__primary usa-accordion">
-                        <li class="usa-nav__primary-item">
-                            <a class="usa-nav__link" href="{% url 'logout' %}"><span>Logout</span></a>
-                        </li>
-                    </ul>
-                </nav>
+                {% if user.is_authenticated %}
+                    <nav aria-label="Primary navigation" class="usa-nav">
+                        <button class="usa-nav__close"><img src="{% static '/img/close.svg' %}" alt="close"></button>
+                        <ul class="usa-nav__primary usa-accordion">
+                            <li class="usa-nav__primary-item">
+                                <a class="usa-nav__link" href="{% url 'logout' %}"><span>Logout</span></a>
+                            </li>
+                        </ul>
+                    </nav>
+                {% endif %}
             </div>
         </header>
 

--- a/data_driven_acquisition/templates/base_uswds_with_sidebar.html
+++ b/data_driven_acquisition/templates/base_uswds_with_sidebar.html
@@ -1,6 +1,8 @@
 {% extends 'base_uswds.html' %}
 {% load static %}
 
+{% block title %}{{ package.name }} | {{ block.super }}{% endblock %}
+
 {% block content %}
 
 <div class="usa-layout-docs usa-section">

--- a/data_driven_acquisition/templates/file_document.html
+++ b/data_driven_acquisition/templates/file_document.html
@@ -1,51 +1,66 @@
-{% extends 'base_with_sidebar.html' %}
+{% extends 'base_uswds_with_sidebar.html' %}
 {% load static %}
 
-{% block title %}DDA - File Editor {{ file.name }} {% endblock %}
+{% block title %}{{ file.name }} | {{ block.super }}{% endblock %}
 
-{% block addtional_head %} 
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
-
+{% block additional_head %}
+    <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
 {% endblock %}
 
+{% block mainbar %}
 
-{% block meat %}
+{% if can_edit %}
+    <h1 class="text-primary">Editing {{ file.name }}</h1>
+{% else %}
+    <h1 class="text-primary">Viewing {{ file.name }}</h1>
+{% endif %}
 
 
-<div id='file_header' class="card">
-    {% if can_edit %}
-        <h4> Editing {{ file.name }}</h4>
-    {% else %}
-        <h4> Viewing {{ file.name }}</h4>
-    {% endif %}
+{% if can_edit %}
+    <form method="POST">
+        {% csrf_token %}
+        <div id="editor"></div>
+
+        <script>
+            Promise.all([
+                new Promise((resolve) => {
+                    tinymce.init({
+                        selector: '#editor',
+                        height: '75vh',
+                        plugins: 'save',
+                        menubar: 'file edit view insert format tools table tc help',
+                        toolbar: 'save | undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | a11ycheck ltr rtl | showcomments addcomment',
+                        init_instance_callback: resolve
+                    });
+                }),
+                new Promise((resolve) => {
+                    $.get("{{ raw_url }}", resolve);
+                })
+            ]).then(([editor, content]) => {
+                editor.setContent(content);
+            });
+        </script>
+    </form>
+{% else %}
+    <iframe src="{{ raw_url }}" class="border-0 width-full height-mobile js-resize-to-contents"></iframe>
+    <script>
+        (() => {
+            const iframe = document.querySelector('.js-resize-to-contents');
+
+            const resizeIframe = (evt) => {
+                const height = iframe.contentWindow.document.documentElement.scrollHeight + 'px';
+
+                if (iframe.style.height !== height) {
+                    iframe.style.height = height;
+                }
+            };
+
+            ['DOMContentLoaded', 'resize'].forEach((evt) => {
+                iframe.contentWindow.addEventListener(evt, resizeIframe);
+            })
+        })();
+    </script>
+{% endif %}
 </div>
-
-
-<div id='file_store' class="card">
-    {% if can_edit %}
-        <form method="post">
-            <div id="editor"></div>
-            {% csrf_token %}
-        </form>
-
-    {% else %}
-        <iframe id="file_viewer" src="{{ raw_url }}"></iframe>
-    {% endif %}
-</div>
-{% endblock %}
-
-
-{% block extra_script %}
-  tinymce.init({
-    selector: '#editor',
-    height: '75vh',
-    plugins: "save",
-    menubar: 'file edit view insert format tools table tc help',
-    toolbar: 'save | undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | a11ycheck ltr rtl | showcomments addcomment',
-  });
-
-$.get("{{ raw_url }}", function(content) { 
-    tinyMCE.activeEditor.setContent(content);
-});
 
 {% endblock %}

--- a/data_driven_acquisition/templates/file_sheet.html
+++ b/data_driven_acquisition/templates/file_sheet.html
@@ -1,89 +1,73 @@
-{% extends 'base_with_sidebar.html' %}
+{% extends 'base_uswds_with_sidebar.html' %}
 {% load static %}
 
-{% block title %}DDA - File Editor {{ file.name }} {% endblock %}
+{% block title %}{{ file.name }} | {{ block.super }}{% endblock %}
 
-{% block addtional_head %} 
-{% comment %} <link rel="stylesheet" href="https://unpkg.com/x-data-spreadsheet@1.0.13/dist/xspreadsheet.css">
-<script src="https://unpkg.com/x-data-spreadsheet@1.0.13/dist/xspreadsheet.js"></script> {% endcomment %}
-
-<script src="{% static '/sheets/webix/webix.js' %}" type="text/javascript"></script>
-<script src="{% static '/sheets/spreadsheet.js' %}" type="text/javascript"></script>
-
-<link rel="stylesheet" type="text/css" href="{% static '/sheets/webix/webix.css' %}">
-<link rel="stylesheet" type="text/css" href="{% static '/sheets/spreadsheet.css' %}">
-
-
+{% block additional_head %}
+    <script src="{% static '/sheets/webix/webix.js' %}" type="text/javascript"></script>
+    <script src="{% static '/sheets/spreadsheet.js' %}" type="text/javascript"></script>
+    <link rel="stylesheet" type="text/css" href="{% static '/sheets/webix/webix.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static '/sheets/spreadsheet.css' %}">
 {% endblock %}
 
 
-{% block meat %}
+{% block mainbar %}
 
+{% if can_edit %}
+    <h1 class="text-primary">
+        <button class="usa-button usa-button--outline float-right" id='save_sheet' type="button">Save</button>
+        {% csrf_token %}
+        Editing {{ file.name }}
+    </h1>
+{% else %}
+    <h1 class="text-primary">Viewing {{ file.name }}</h1>
+{% endif %}
 
-<div id='file_header' class="card">
-    {% if can_edit %}
-        <nav class="navbar navbar-expand-lg navbar-light bg-light">
-          <a class="navbar-brand" href="#">Editing {{ file.name }}</a>
-          <button class="btn btn-outline-secondary my-2 my-sm-0"
-          id='save_sheet' type="button">Save</button>
-        </nav>
-    {% else %}
-        <h4> Viewing {{ file.name }}</h4>
-    {% endif %}
-</div>
+<div id='file_store' class="width-full" style='height:75vh;'></div>
 
-<div id='file_store' class="" style='height:75vh;'>
-</div>
-{% endblock %}
+<script>
+    webix.ready(function () {
+        // object constructor
+        webix.ui({
+            view: 'spreadsheet',
+            id: 'ssheet',
+            container: 'file_store',
+            liveEditor: true,
+            menu: false,
+            bottombar: true,
+            toolbar: 'full',
 
+            // loaded data object
+            data: {{ file.content|safe }}
+        });
 
-{% block extra_script %}
-   
-webix.ready(function(){
+        $$('ssheet').attachEvent('onCellChange', function (row, column, value) {
+            $('#save_sheet').removeClass('usa-button--outline');
+        });
 
+        $('#save_sheet').click(function () {
+            var sheet_data = $$('ssheet').serialize({sheets: true});
 
-    //object constructor
-    webix.ui({
-        view:"spreadsheet",
-        id:"ssheet",
-        container:"file_store",
-        liveEditor: true,
-        menu: false,
-        bottombar:true,
-        toolbar:"full",
-        //loaded data object
-        data: {{ file.content|safe }}
-    });
+            // Cleanup up driver element that trigger this bug
+            // https://forum.webix.com/discussion/36947/spreadsheet-insert-column-row-not-working
+            for (var sheet in sheet_data) {
+                if (sheet_data[sheet].hasOwnProperty('driver')) {
+                    console.log(sheet_data[sheet]['driver']);
+                    delete sheet_data[sheet]['driver']
+                }
+            }
 
-    $$("ssheet").attachEvent("onCellChange", function(row, column, value){
-        {% comment %} console.log("Row: "+row+"; column: "+column+"; new value: "+value) {% endcomment %}
-        $( "#save_sheet" ).addClass( 'btn-success' );
-        $( "#save_sheet" ).removeClass( 'btn-outline-secondary' );
-    });
-
-   $('#save_sheet').click(function() {
-        var sheet_data = $$("ssheet").serialize({sheets: true});
-
-        // Cleanup up driver element that trigger this bug
-        // https://forum.webix.com/discussion/36947/spreadsheet-insert-column-row-not-working
-        for (var sheet in sheet_data) {
-            if (sheet_data[sheet].hasOwnProperty("driver")) {
-                console.log(sheet_data[sheet]["driver"]);
-                delete sheet_data[sheet]["driver"]
-            } 
-        }
-
-        $.ajax({
-            type: "POST",
-            url: '{% url 'rawfile' file.id %}',
-            data: {'rawdata': JSON.stringify(sheet_data)},
-            success: function(out){
-                $( "#save_sheet" ).addClass( 'btn-outline-secondary' );
-                $( "#save_sheet" ).removeClass( 'btn-success' );
-            },
+            $.ajax({
+                type: 'POST',
+                url: '{% url 'rawfile' file.id %}',
+                data: {'rawdata': JSON.stringify(sheet_data)},
+                headers: { 'X-CSRFToken': $('[name=csrfmiddlewaretoken]').val() },
+                success: function () {
+                    $('#save_sheet').addClass('usa-button--outline');
+                },
+            });
         });
     });
-
-});
+</script>
 
 {% endblock %}

--- a/data_driven_acquisition/templates/package.html
+++ b/data_driven_acquisition/templates/package.html
@@ -1,8 +1,6 @@
 {% extends 'base_uswds_with_sidebar.html' %}
 {% load static %}
 
-{% block title %}{{ package.name }} | {{ block.super }}{% endblock %}
-
 {% block mainbar %}
 
 <h1 class="text-primary">Acquisition properties</h1>

--- a/data_driven_acquisition/templates/registration/login.html
+++ b/data_driven_acquisition/templates/registration/login.html
@@ -1,77 +1,38 @@
-{% extends 'base.html' %}
-
-{% block title %}DDA - Login{% endblock %}
-
-{% block addtional_head %} 
-<style>
-.login-container{
-    margin-top: 5%;
-    margin-bottom: 5%;
-}
-.login-form-1{
-    padding: 5%;
-    box-shadow: 0 5px 8px 0 rgba(0, 0, 0, 0.2), 0 9px 26px 0 rgba(0, 0, 0, 0.19);
-}
-.login-form-1 h3{
-    text-align: center;
-    color: #333;
-}
-}
-.login-container form{
-    padding: 10%;
-}
-.btnSubmit
-{
-    width: 50%;
-    border-radius: 1rem;
-    padding: 1.5%;
-    border: none;
-    cursor: pointer;
-}
-.login-form-1 .btnSubmit{
-    font-weight: 600;
-    color: #fff;
-    background-color: #0062cc;
-}
-.login-form-1 .ForgetPwd{
-    color: #0062cc;
-    font-weight: 600;
-    text-decoration: none;
-}
-</style>
-{% endblock %}
-
+{% extends 'base_uswds.html' %}
 
 {% block content %}
 
+<div class="grid-container usa-section">
+    <h1 class="text-primary">Sign in</h1>
 
-<div class="container login-container">
-    <div class="row">
-        <div class="col-md-6 login-form-1">
-            {% if form.non_field_errors %}
-            <ul class='form-errors'>
-                {% for error in form.non_field_errors %}
-                    <li>{{ error }}</li>
-                {% endfor %}
-            </ul>
-            {% endif %}
-            <h3>Data Driven Acquisition</h3>
-            <form action="" method="POST">
-                {% csrf_token %}
-                <div class="form-group">
-                    <input type="text" class="form-control" placeholder="Your Username *" value="" name="username" id="id_username" required/>
-                </div>
-                <div class="form-group">
-                    <input type="password" class="form-control" placeholder="Your Password *" value="" name="password" id="id_password" required />
-                </div>
-                <div class="form-group">
-                    <input type="submit" class="btnSubmit" value="Login" />
-                </div>
-                <div class="form-group">
-                    <a href="#" class="ForgetPwd">Forget Password?</a>
-                </div>
-            </form>
+    {% if form.non_field_errors %}
+        <div class="usa-alert usa-alert--error" role="alert">
+            <div class="usa-alert__body">
+                <h3 class="usa-alert__heading">Sign in failed.</h3>
+                <ul class="usa-alert__text">
+                    {% for error in form.non_field_errors %}
+                        <li>{{ error }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
         </div>
-    </div>
+    {% endif %}
+
+    <form class="usa-form" method="POST">
+        {% csrf_token %}
+        <fieldset class="usa-fieldset">
+            <legend class="usa-sr-only">Sign in</legend>
+
+            <label class="usa-label" for="username">Username</label>
+            <input class="usa-input" id="username" name="username" type="text" autocapitalize="off" autocorrect="off" required>
+
+            <label class="usa-label" for="password-sign-in">Password</label>
+            <input class="usa-input" id="password-sign-in" name="password" type="password" required>
+            <p class="usa-form__note"><a title="Show password" href="javascript:void(0);" class="usa-show-password" aria-controls="password-sign-in">Show password</a></p>
+
+            <input class="usa-button" type="submit" value="Sign in">
+        </fieldset>
+    </form>
 </div>
+
 {% endblock %}

--- a/data_driven_acquisition/views.py
+++ b/data_driven_acquisition/views.py
@@ -429,8 +429,16 @@ class FileEditor(RevisionMixin, View):
         if not (can_read or can_edit):
             return HttpResponseForbidden('Not permitted to access this file.')
 
+        tree = user_permitted_tree(request.user)
+        for key, value in tree.items():
+            if key.id == the_file.package.id:
+                package_tree = value
+                break
+
         context = genreal_context(self.request)
         context['file'] = the_file
+        context['package'] = the_file.package
+        context['package_tree'] = package_tree
         context['can_read'] = can_read
         context['can_edit'] = can_edit
         context['perm_set'] = perm_set
@@ -496,10 +504,18 @@ class FileEditor(RevisionMixin, View):
             the_file.content = new_content
             the_file.save()
 
-            reversion.set_comment('Edited file content directly.') 
+            reversion.set_comment('Edited file content directly.')
+
+        tree = user_permitted_tree(request.user)
+        for key, value in tree.items():
+            if key.id == the_file.package.id:
+                package_tree = value
+                break
 
         context = genreal_context(self.request)
         context['file'] = the_file
+        context['package'] = the_file.package
+        context['package_tree'] = package_tree
         context['can_read'] = can_read
         context['can_edit'] = can_edit
         context['perm_set'] = perm_set


### PR DESCRIPTION
This pull request fixes #6 and implements the new layouts on the following pages: 

| Page | Preview | 
|------|--------|
| Login | ![Screenshot of login page](https://user-images.githubusercontent.com/14930/72997662-8e66a080-3dca-11ea-8b5b-84905268548f.png) |
| Document editor | ![Screenshot of document editor](https://user-images.githubusercontent.com/14930/72997748-b9e98b00-3dca-11ea-96bc-3dec6e031141.png) |
| Document viewer (for accounts that cannot edit) | ![Screenshot of document viewer](https://user-images.githubusercontent.com/14930/72997854-ef8e7400-3dca-11ea-8e64-a85d668c6b7a.png) |
| Sheet editor | ![Screenshot of sheet editor](https://user-images.githubusercontent.com/14930/72997923-0cc34280-3dcb-11ea-9eb5-c99b9c2f217e.png) |
| Sheet viewer (for accounts that cannot edit) | ![Screenshot of sheet viewer](https://user-images.githubusercontent.com/14930/72998057-3f6d3b00-3dcb-11ea-9b57-a5ae58e71095.png) |

I think this layout doesn’t work particularly well for the editor views, given that the document and (especially) the sheet editors need significantly more horizontal space. 

Opened #13 to discuss and track potential changes to the layout. 