### PR TITLE
Expand sidebar to current item, add sidebar icons, remove file extensions.

### DIFF
--- a/data_driven_acquisition/models.py
+++ b/data_driven_acquisition/models.py
@@ -355,6 +355,16 @@ class File(TimeStampedModel, SoftDeletableModel):
             p = p.parent
         return p
 
+    @property
+    def extname(self):
+        """Return the file’s extension"""
+        return self.name.split('.')[-1]
+
+    @property
+    def basename(self):
+        """Return the file’s name without extension"""
+        return ''.join(self.name.split('.')[:-1])
+
 
 class PackageProperty(TimeStampedModel, SoftDeletableModel):
     """A property definition for an acquisition."""

--- a/data_driven_acquisition/static/css/dda.css
+++ b/data_driven_acquisition/static/css/dda.css
@@ -86,6 +86,7 @@
   background: none;
   font-weight: normal;
   display: block;
+  color: #565c65;
   padding: 0.5rem 2rem 0.5rem 1rem;
   background-position: right 0.5rem center;
   background-size: 0.5rem;

--- a/data_driven_acquisition/templates/base_uswds.html
+++ b/data_driven_acquisition/templates/base_uswds.html
@@ -14,6 +14,7 @@
         <link rel="stylesheet" type="text/css" href="{% static '/css/dda.css' %}">
         <script src="{% static '/js/jquery-3.4.1.min.js' %}"></script>
         <script src="{% static '/js/uswds.js' %}"></script>
+        <script src="https://kit.fontawesome.com/483d3f255b.js" crossorigin="anonymous"></script>
         {% block additional_head %} {% endblock %}
     </head>
     <body class="{% block body_class %}{% endblock %}">

--- a/data_driven_acquisition/templates/base_uswds_with_sidebar.html
+++ b/data_driven_acquisition/templates/base_uswds_with_sidebar.html
@@ -30,4 +30,12 @@
     </div>
 </div>
 
+<script>
+    $(document).ready(() => {
+        $('.dda-sidenav-tree .usa-current').parents('[hidden]').each((i, el) => {
+            $(`[aria-controls='${el.id}']`).click();
+        });
+    });
+</script>
+
 {% endblock %}

--- a/data_driven_acquisition/templates/base_uswds_with_sidebar.html
+++ b/data_driven_acquisition/templates/base_uswds_with_sidebar.html
@@ -14,7 +14,10 @@
                     <ul class="usa-sidenav usa-accordion dda-sidenav-tree" aria-multiselectable="true">
                         <li class="usa-sidenav__item">
                             {% url 'package' package_id=package.id as link %}
-                            <a href="{{ link }}" class="{% if link == request.path %}usa-current{% endif %}">Acquisition properties</a>
+                            <a href="{{ link }}" class="{% if link == request.path %}usa-current{% endif %}">
+                                <i class="fas fa-file-alt margin-right-05"></i>
+                                Acquisition properties
+                            </a>
                         </li>
                         {% include 'sidebar_item.html' with items=package_tree.items %}
                     </ul>

--- a/data_driven_acquisition/templates/sidebar_item.html
+++ b/data_driven_acquisition/templates/sidebar_item.html
@@ -1,16 +1,26 @@
 {% for key, value in items %}
     {% if key == 'files' %}
-        {% for item in value %}
+        {% for file in value %}
             <li class="usa-sidenav__item">
-                {% url 'file' file_id=item.id as link %}
+                {% url 'file' file_id=file.id as link %}
                 <a href="{{ link }}" class="{% if link == request.path %}usa-current{% endif %}">
-                    {{ item.name }}
+                    {% if file.extname == 'json' %}
+                        <i class="fas fa-file-excel margin-right-05"></i>
+                    {% elif file.extname == 'html' %}
+                        <i class="fas fa-file-word margin-right-05"></i>
+                    {% elif file.extname == 'pdf' %}
+                        <i class="fas fa-file-pdf margin-right-05"></i>
+                    {% else %}
+                        <i class="fas fa-file margin-right-05"></i>
+                    {% endif %}
+                    {{ file.basename }}
                 </a>
             </li>
         {% endfor %}
     {% else %}{% comment %} key = Folder object {% endcomment %}
         <li class="usa-sidenav__item">
             <button class="usa-accordion__button" aria-controls="sidenav-folder-{{key.id}}">
+                <i class="fas fa-folder margin-right-05"></i>
                 {{ key.name }}
             </button>
             <ul class="usa-sidenav__sublist" id="sidenav-folder-{{key.id}}">

--- a/data_driven_acquisition/templates/sidebar_item.html
+++ b/data_driven_acquisition/templates/sidebar_item.html
@@ -14,7 +14,7 @@
                 {{ key.name }}
             </button>
             <ul class="usa-sidenav__sublist" id="sidenav-folder-{{key.id}}">
-                {% include 'sidebar_item.html' with items=value.items only %}
+                {% include 'sidebar_item.html' with items=value.items %}
             </ul>
         </li>
     {% endif %}


### PR DESCRIPTION
Fixes #16, a follow-up to #9.

This PR implements two new methods on `File` and uses them in rendering the sidebar and selecting icons: 

- `File#extname` to return the file’s extension.
- `File#basename` to return the file’s name without extension.

Additionally, it fixes a text color issue and opens the sidebar to the current item on page load.