### PR TITLE
Combine Save and Update buttons, add loading text.

### DIFF
--- a/data_driven_acquisition/templates/new.html
+++ b/data_driven_acquisition/templates/new.html
@@ -17,9 +17,15 @@
         {% include 'form.html' %}
 
         <div class="grid-row margin-top-3 padding-y-4 position-sticky bottom-0 bg-white dda-fade__above border-top-1px border-base-light">
-            <button class="usa-button">Save properties</button>
+            <button class="usa-button js-submit">Save properties</button>
         </div>
     </form>
 </div>
+
+<script>
+    $('form').submit(() => {
+        $('.js-submit').addClass('usa-button--disabled').text('Saving…')
+    });
+</script>
 
 {% endblock %}

--- a/data_driven_acquisition/templates/package.html
+++ b/data_driven_acquisition/templates/package.html
@@ -13,10 +13,8 @@
     {% include 'form.html' %}
 
     <div class="grid-row flex-align-center margin-top-3 padding-y-4 position-sticky bottom-0 bg-white dda-fade__above border-top-1px border-base-light">
-        <button class="usa-button"{% if not can_edit %} disabled{% endif %}>Save properties</button>
+        <button class="usa-button js-submit"{% if not can_edit %} disabled{% endif %}>Save properties</button>
         {% if not can_edit %}<span class="usa-hint">You cannot edit this package.</span>{% endif %}
-        <button class="usa-button usa-button--outline js-update-content" type="button"{% if not can_push %} disabled{% endif %}>Update content</button>
-        {% if not can_push %}<span class="usa-hint">You cannot push updates to the content of this package.</span>{% endif %}
 
         {% if trello_url %}
             <a href="{{trello_url}}" target="trello" rel="noopener noreferrer" class="usa-button usa-button--unstyled">
@@ -27,16 +25,8 @@
 </form>
 
 <script>
-    $('.js-update-content').on('click', function () {
-        $.ajax({
-            url: "{% url 'package' package_id=package.id %}",
-            type: "PUT",
-            headers: { 'X-CSRFToken': $('[name=csrfmiddlewaretoken]').val() },
-            cache: false,
-            success: function (resp) {
-                alert(resp.status);
-            }
-        });
+    $('form').submit(() => {
+        $('.js-submit').addClass('usa-button--disabled').text('Saving…')
     });
 </script>
 


### PR DESCRIPTION
Closes #15.

This PR unifies the Save and Update buttons into the Save action, and replaces the submit buttons on the Create and Edit forms with “Saving…” while the form is being submit.