### PR TITLE
Use side navigation for tabs on editors.

### DIFF
--- a/data_driven_acquisition/static/css/dda.css
+++ b/data_driven_acquisition/static/css/dda.css
@@ -22,40 +22,8 @@
   color: white;
 }
 
-/* Tab control */
-
-.dda-tabs .dda-tabs__heading-container {
-  background: white;
-  border-bottom: 1px solid #a9aeb1;
-  padding: 1rem 1rem 0;
-  z-index: 1;
-}
-
-.dda-tabs .usa-accordion__heading {
-  margin: 0 0.25rem -1px;
-}
-
-.dda-tabs .usa-accordion__button {
-  background: none;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid;
-  border-color: #a9aeb1 #a9aeb1 transparent;
-  border-radius: 0.25rem 0.25rem 0 0;
-  text-transform: uppercase;
-}
-
-.dda-tabs .usa-accordion__button[aria-expanded="true"] {
-  background-color: white;
-  pointer-events: none;
-  color: #005ea2;
-}
-
-.dda-tabs .usa-accordion__button[aria-expanded="false"] {
-  border-color: transparent transparent #a9aeb1;
-  font-weight: normal;
-}
-
 /* Fade for sticky content */
+
 .dda-fade__below:after {
   display: block;
   content: "";

--- a/data_driven_acquisition/templates/base_uswds_with_sidebar.html
+++ b/data_driven_acquisition/templates/base_uswds_with_sidebar.html
@@ -10,11 +10,13 @@
         <div class="grid-row grid-gap">
             <aside class="usa-layout-docs__sidenav desktop:grid-col-3">
                 <h1 class="text-primary">{{package.name}}</h1>
-                <nav aria-label="Secondary navigation">
+                <nav aria-label="Secondary navigation" class="position-sticky top-2">
                     <ul class="usa-sidenav usa-accordion dda-sidenav-tree" aria-multiselectable="true">
                         <li class="usa-sidenav__item">
-                            {% url 'package' package_id=package.id as link %}
-                            <a href="{{ link }}" class="{% if link == request.path %}usa-current{% endif %}">Acquisition properties</a>
+                            {% block sidenav_first_item %}
+                                {% url 'package' package_id=package.id as link %}
+                                <a href="{{ link }}" class="{% if link == request.path %}usa-current{% endif %}">Acquisition properties</a>
+                            {% endblock %}
                         </li>
                         {% include 'sidebar_item.html' with items=package_tree.items %}
                     </ul>

--- a/data_driven_acquisition/templates/form.html
+++ b/data_driven_acquisition/templates/form.html
@@ -11,44 +11,35 @@
     </select>
 {% endif %}
 
-<div class="usa-accordion dda-tabs">
-    <div class="grid-row margin-top-3 dda-tabs__heading-container position-sticky top-0 dda-fade__below">
-        {% for tab, tab_name in tabs.items %}
-            <h2 class="usa-accordion__heading">
-                <button class="usa-accordion__button" role="tab" aria-controls="nav-{{tab}}"{% if forloop.first %} aria-expanded="true"{% endif %}>{{tab_name}}</button>
-            </h2>
+{% for tab, props in tab_dict.items %}
+    <fieldset id="{{tab | slugify}}" class="usa-fieldset margin-y-6">
+        <legend class="usa-legend text-primary font-sans-lg padding-top-2">{{tab}}</legend>
+        {% for prop in props %}
+            <label for="{{prop.name}}_id" class="usa-label text-bold">{{prop.name}}</label>
+            <p class="usa-hint maxw-mobile-lg" id="{{prop.name}}_help">{{prop.description}}</p>
+
+            {% if prop.widget == 'textarea' %}
+                <textarea name="prop_{{prop.id}}" class="usa-textarea" id="{{prop.name}}_id" aria-describedby="{{prop.name}}_help"{% if not can_edit %} disabled{% endif %}>{{prop.value|default:""}}</textarea>
+            {% elif prop.widget == 'radio' %}
+                <fieldset class="usa-fieldset">
+                    <legend class="usa-sr-only">{{prop.name}}</legend>
+                    {% for opt in prop.options %}
+                        <div class="usa-radio">
+                            <input class="usa-radio__input" id="{{prop.name}}_{{opt}}_id" value="{{opt}}" type="radio" name="prop_{{prop.id}}"{% if prop.value == opt %} checked{% endif %}{% if not can_edit %} disabled{% endif %}>
+                            <label class="usa-radio__label" for="{{prop.name}}_{{opt}}_id">{{opt}}</label>
+                        </div>
+                    {% endfor %}
+                </fieldset>
+            {% elif prop.widget == 'dropdown' %}
+                <select name="prop_{{prop.id}}" class="usa-select" id="{{prop.name}}_id" aria-describedby="{{prop.name}}_help"{% if not can_edit %} disabled{% endif %}>
+                    <option value="">- Select -</option>
+                    {% for opt in prop.options %}
+                        <option value="{{opt}}" {% if prop.value == opt %}selected{% endif %}>{{opt}}</option>
+                    {% endfor %}
+                </select>
+            {% else %}
+                <input name="prop_{{prop.id}}" type="text" class="usa-input" id="{{prop.name}}_id" value="{{prop.value|default:""}}" aria-describedby="{{prop.name}}_help"{% if not can_edit %} disabled{% endif %}>
+            {% endif %}
         {% endfor %}
-    </div>
-
-    {% for tab, props in tab_dict.items %}
-        <div id="nav-{{tab}}" class="usa-accordion__content padding-top-3 padding-left-0 padding-right-0 overflow-visible">
-            {% for prop in props %}
-                <label for="{{prop.name}}_id" class="usa-label text-bold">{{prop.name}}</label>
-                <p class="usa-hint maxw-mobile-lg" id="{{prop.name}}_help">{{prop.description}}</p>
-
-                {% if prop.widget == 'textarea' %}
-                    <textarea name="prop_{{prop.id}}" class="usa-textarea" id="{{prop.name}}_id" aria-describedby="{{prop.name}}_help"{% if not can_edit %} disabled{% endif %}>{{prop.value|default:""}}</textarea>
-                {% elif prop.widget == 'radio' %}
-                    <fieldset class="usa-fieldset">
-                        <legend class="usa-sr-only">{{prop.name}}</legend>
-                        {% for opt in prop.options %}
-                            <div class="usa-radio">
-                                <input class="usa-radio__input" id="{{prop.name}}_{{opt}}_id" value="{{opt}}" type="radio" name="prop_{{prop.id}}"{% if prop.value == opt %} checked{% endif %}{% if not can_edit %} disabled{% endif %}>
-                                <label class="usa-radio__label" for="{{prop.name}}_{{opt}}_id">{{opt}}</label>
-                            </div>
-                        {% endfor %}
-                    </fieldset>
-                {% elif prop.widget == 'dropdown' %}
-                    <select name="prop_{{prop.id}}" class="usa-select" id="{{prop.name}}_id" aria-describedby="{{prop.name}}_help"{% if not can_edit %} disabled{% endif %}>
-                        <option value="">- Select -</option>
-                        {% for opt in prop.options %}
-                            <option value="{{opt}}" {% if prop.value == opt %}selected{% endif %}>{{opt}}</option>
-                        {% endfor %}
-                    </select>
-                {% else %}
-                    <input name="prop_{{prop.id}}" type="text" class="usa-input" id="{{prop.name}}_id" value="{{prop.value|default:""}}" aria-describedby="{{prop.name}}_help"{% if not can_edit %} disabled{% endif %}>
-                {% endif %}
-            {% endfor %}
-        </div>
-    {% endfor %}
-</div>
+    </fieldset>
+{% endfor %}

--- a/data_driven_acquisition/templates/new.html
+++ b/data_driven_acquisition/templates/new.html
@@ -1,25 +1,36 @@
-{% extends 'base_uswds.html' %}
+{% extends 'base_uswds_with_sidebar.html' %}
 {% load static %}
 
-{% block title %}New Acquistion | {{block.super}}{% endblock %}
+{% block title %}New {{ template.title }}{{block.super}}{% endblock %}
 
-{% block content %}
+{% block sidenav_first_item %}
+    <li class="usa-sidenav__item">
+        <a href="#main-content" class="usa-current">Acquisition properties</a>
+        <ul class="usa-sidenav__sublist">
+            {% for tab, tab_name in tabs.items %}
+                <li class="usa-sidenav__item">
+                    <a href="#{{ tab }}">{{tab_name}}</a>
+                </li>
+            {% endfor %}
+        </ul>
+    </li>
+{% endblock %}
 
-<div class="grid-container usa-section">
-    <h1 class="text-primary">New {{ template.title }}</h1>
+{% block mainbar %}
 
-    {% include 'form_status.html' %}
+<h1 class="text-primary">New {{ template.title }}</h1>
 
-    <form method="POST">
-        {% csrf_token %}
-        <input type="hidden" name="template_id" value="{{template.id}}">
+{% include 'form_status.html' %}
 
-        {% include 'form.html' %}
+<form method="POST">
+    {% csrf_token %}
+    <input type="hidden" name="template_id" value="{{template.id}}">
 
-        <div class="grid-row margin-top-3 padding-y-4 position-sticky bottom-0 bg-white dda-fade__above border-top-1px border-base-light">
-            <button class="usa-button">Save properties</button>
-        </div>
-    </form>
-</div>
+    {% include 'form.html' %}
+
+    <div class="grid-row margin-top-3 padding-y-4 position-sticky bottom-0 bg-white dda-fade__above border-top-1px border-base-light">
+        <button class="usa-button">Save properties</button>
+    </div>
+</form>
 
 {% endblock %}

--- a/data_driven_acquisition/templates/package.html
+++ b/data_driven_acquisition/templates/package.html
@@ -1,6 +1,17 @@
 {% extends 'base_uswds_with_sidebar.html' %}
 {% load static %}
 
+{% block sidenav_first_item %}
+    {{ block.super }}
+    <ul class="usa-sidenav__sublist">
+        {% for tab, tab_name in tabs.items %}
+            <li class="usa-sidenav__item">
+                <a href="#{{ tab }}">{{tab_name}}</a>
+            </li>
+        {% endfor %}
+    </ul>
+{% endblock %}
+
 {% block mainbar %}
 
 <h1 class="text-primary">Acquisition properties</h1>

--- a/data_driven_acquisition/templates/package.html
+++ b/data_driven_acquisition/templates/package.html
@@ -18,7 +18,7 @@
 
 {% include 'form_status.html' %}
 
-<form method="POST">
+<form action="{% url 'package' package_id=package.id %}" method="POST">
     {% csrf_token %}
 
     {% include 'form.html' %}

--- a/data_driven_acquisition/utils.py
+++ b/data_driven_acquisition/utils.py
@@ -22,7 +22,7 @@ def apply_properties(data, properties):
         Apply the provided properties to a data string following one of these
         formats:
 
-        1. "{{ Property Name }}" : The entire string will be replaces with the value. 
+        1. "{{ Property Name }}" : The entire string will be replaces with the value.
         2. <!--PROPERTY:property_name-->VALUE<!--/PROPERTY:property_name--> The
             value will replace the string between the comments. Leaving the comments
             in place for later update.
@@ -203,9 +203,9 @@ def package_prop_by_tab(package, tabs, template=False):
     out = {}
     for tab in tabs:
         if template:
-            out[slugify(tab[0])] = package.properties.filter(tab=tab[0])
+            out[tab[0]] = package.properties.filter(tab=tab[0])
         else:
-            out[slugify(tab[0])] = package.properties.filter(prop__tab=tab[0])
+            out[tab[0]] = package.properties.filter(prop__tab=tab[0])
     return out
 
 


### PR DESCRIPTION
Fixes #17.

This PR moves the tab navigation of the package editors to the side navigation, jumping to the appropriate place in the page when clicked: 

![ezgif-2-42637a98b9cd](https://user-images.githubusercontent.com/14930/73558089-77eec380-4420-11ea-9e80-1f1ef4df948b.gif)
