### PR TITLE
Fix bug in fetching properties by name.

### DIFF
--- a/data_driven_acquisition/models.py
+++ b/data_driven_acquisition/models.py
@@ -260,18 +260,18 @@ class Folder(TimeStampedModel, StatusModel, SoftDeletableModel):
 
     @property
     def agency_partner(self):
-        return self.get_package_property_by_name('Agency-Partner').value or ''
+        return self.get_package_value_by_name('Agency-Partner')
 
     @property
     def office_team(self):
-        return self.get_package_property_by_name('Office Team').value or ''
+        return self.get_package_value_by_name('Office Team')
 
     @property
     def office(self):
-        return self.get_package_property_by_name('Office').value or ''
+        return self.get_package_value_by_name('Office')
 
 
-    def get_package_property_by_name(self, name):
+    def get_package_value_by_name(self, name):
         prop = self.properties.filter(prop__name=name)
         if len(prop) >= 1:
             return prop[0]

--- a/data_driven_acquisition/utils.py
+++ b/data_driven_acquisition/utils.py
@@ -351,7 +351,7 @@ def trello_card_desc(package, tabs):
 
     properties  = package_prop_by_tab(package, tabs)
     tab_names = sorted(properties)
-    title = package.get_package_property_by_name('Title').value
+    title = package.get_package_value_by_name('Title')
 
     desc = f'**Title:** {title}\n'
     desc += '=============\n'


### PR DESCRIPTION
This PR fixes a bug when fetching properties that don’t exist: 

- If a property doesn’t exist, an empty string is returned. 
- Python then tries to call `''.value`, which throws.

Since this method is only used in places where `.value` is immediately called, this PR switches the function to call `.value` automatically, returning a string in all cases.