### PR TITLE
Add pagination to homepage.

### DIFF
--- a/data_driven_acquisition/templates/home.html
+++ b/data_driven_acquisition/templates/home.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load url_replace %}
 
 {% block body_class %}bg-base-lightest{% endblock %}
 
@@ -31,7 +32,7 @@
         </div>
     </div>
 
-    {% if packages|length == 0 %}
+    {% if page.paginator.count == 0 %}
         <div class="grid-row margin-top-4">
             There are no acquisitions.
         </div>
@@ -89,7 +90,7 @@
                     <th scope="col">Office</th>
                 </thead>
                 <tbody>
-                    {% for package in packages %}
+                    {% for package in page %}
                         <tr>
                             <td><a href="{% url 'package' package_id=package.id %}">{{ package.id }}</a></td>
                             <td><a href="{% url 'package' package_id=package.id %}">{{ package.name }}</a></td>
@@ -100,6 +101,19 @@
                     {% endfor %}
                 </tbody>
             </table>
+        </div>
+        <div class="grid-row grid-gap flex-align-center margin-top-2">
+            {% if page.has_previous %}
+                <a href="{% url_replace page=page.previous_page_number %}" class="usa-button usa-button--outline">Previous</a>
+            {% endif %}
+
+            <span>
+                Page {{ page.number }} of {{ page.paginator.num_pages }}.
+            </span>
+
+            {% if page.has_next %}
+                <a href="{% url_replace page=page.next_page_number %}" class="usa-button usa-button--outline">Next</a>
+            {% endif %}
         </div>
     {% endif %}
 </div>

--- a/data_driven_acquisition/templatetags/url_replace.py
+++ b/data_driven_acquisition/templatetags/url_replace.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def url_replace(context, **kwargs):
+    params = context['request'].GET.copy()
+    for k, v in kwargs.items():
+        params[str(k)] = v
+    return context['request'].path + '?' + params.urlencode()

--- a/data_driven_acquisition/views.py
+++ b/data_driven_acquisition/views.py
@@ -9,6 +9,7 @@ from django.http import JsonResponse, HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, render, redirect
 from django.core.exceptions import ValidationError
 from django.conf import settings
+from django.core.paginator import Paginator
 
 from data_driven_acquisition.models import Folder, File, PackageTemplate, PackageProperty
 from data_driven_acquisition.utils import (
@@ -51,6 +52,8 @@ class HomePageView(TemplateView):
 
     template_name = "home.html"
 
+    page_size = 20
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update(genreal_context(self.request))
@@ -62,7 +65,9 @@ class HomePageView(TemplateView):
         context['office'] = self.request.GET.get('office')
         context['current_user'] = self.request.user
 
-
+        paginator = Paginator(list(context['packages']), self.page_size)
+        page = paginator.get_page(self.request.GET.get('page'))
+        context['page'] = page
 
         try:
             context['offices'] = PackageProperty.objects.get(name='Office').options


### PR DESCRIPTION
This PR implements basic pagination on the homepage. 

A custom template tag is implemented to handle updating only the `page` querystring parameter in the pagination links, as the querystring params are also used for filtering parameters.